### PR TITLE
Improve album art accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ MP3ME is a user-friendly tool that helps you search and download your favourite 
 
 * Customisable accent colour in the settings
 * Quick access to the application log file
+* Official album art is embedded in downloaded songs when available
 
 
 ## 🚀 Release Timeline

--- a/mp3me.py
+++ b/mp3me.py
@@ -4647,12 +4647,42 @@ def fetch_better_release_artwork(release_title, artist_name):
     Falls back to YouTube thumbnail if not found.
     """
     try:
-        # For now just return None - this would be implemented with actual
-        # cover art API in a production version
-        return None
+        # Build query for iTunes Search API
+        query = f"{release_title} {artist_name}"
+        params = {
+            "term": query,
+            "entity": "album",
+            "limit": 5
+        }
+
+        response = NetworkManager.request_with_retry(
+            "https://itunes.apple.com/search", params=params, timeout=10
+        )
+        if response.status_code != 200:
+            return None
+
+        results = response.json().get("results", [])
+        release_lower = release_title.lower()
+        artist_lower = artist_name.lower()
+
+        for r in results:
+            album = r.get("collectionName", "").lower()
+            artist = r.get("artistName", "").lower()
+            if release_lower in album and artist_lower in artist:
+                artwork = r.get("artworkUrl100")
+                if artwork:
+                    return artwork.replace("100x100bb", "600x600bb")
+
+        # Fallback to first result if nothing matches perfectly
+        if results:
+            artwork = results[0].get("artworkUrl100")
+            if artwork:
+                return artwork.replace("100x100bb", "600x600bb")
+
     except Exception as e:
         logger.warning(f"Failed to fetch better release art: {e}")
-        return None
+
+    return None
 
 
 def fetch_artist_details(artist_url, artist_id):


### PR DESCRIPTION
## Summary
- fetch album artwork from the iTunes Search API
- embed the official art in downloaded songs
- mention this feature in the README

## Testing
- `python -m py_compile mp3me.py`

------
https://chatgpt.com/codex/tasks/task_e_684035e95274832b86eba341602bfa29