### PR TITLE
Fix missing import for QDialogButtonBox

### DIFF
--- a/mp3me.py
+++ b/mp3me.py
@@ -53,7 +53,8 @@ from PyQt6.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout,
                             QRadioButton, QButtonGroup, QToolButton, QSystemTrayIcon,
                             QSizePolicy, QGraphicsOpacityEffect, QTableWidget,
                             QTableWidgetItem, QHeaderView, QTextEdit, QColorDialog,
-                            QWizard, QWizardPage, QStackedWidget, QStyle)
+                            QWizard, QWizardPage, QStackedWidget, QStyle,
+                            QDialogButtonBox)
 
 # Add qtawesome for better icons
 try:


### PR DESCRIPTION
## Summary
- include `QDialogButtonBox` in the PyQt6 imports

## Testing
- `python -m py_compile mp3me.py`

------
https://chatgpt.com/codex/tasks/task_e_68403cfb4ab4832b970dfe166d7c4cc2