### PR TITLE
Fix tray quit when window hidden

### DIFF
--- a/mp3me.py
+++ b/mp3me.py
@@ -2661,6 +2661,8 @@ class MainWindow(QMainWindow):
                 return
         self.exit_requested = True
         self.close()
+        # Ensure the Qt event loop exits even if the window is hidden
+        QApplication.instance().quit()
 
     def update_network_indicator(self, connected: bool):
         """Update the network status indicator."""


### PR DESCRIPTION
## Summary
- ensure quitting from the system tray exits the event loop

## Testing
- `python3 -m py_compile mp3me.py`

------
https://chatgpt.com/codex/tasks/task_e_68403cda50b4832ba41bbddaf54e92e4